### PR TITLE
Fix BadHostKeyException raised by paramiko when reusing ssh session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,8 @@
+1.0.1 (06/11/2017)
+------------------
+- Fix BadHostKeyException raised by paramiko when reusing same ssh session object to connect to a different
+  remote host having same IP than previous host (just TCP port is different)
+
+1.0.0 (05/24/2017)
+------------------
+- First release

--- a/jumpssh/pkg_info.json
+++ b/jumpssh/pkg_info.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Thibaud Castaing"
 }

--- a/jumpssh/session.py
+++ b/jumpssh/session.py
@@ -182,6 +182,8 @@ class SSHSession(object):
         if hasattr(self, 'ssh_client') and self.is_active():
             logger.info("Closing connection to '%s:%s'..." % (self.host, self.port))
             self.ssh_client.close()
+            # clear local host keys as they may not be valid for next connection
+            self.ssh_client.get_host_keys().clear()
 
     def run_cmd(
             self,


### PR DESCRIPTION
Fix BadHostKeyException raised by paramiko when reusing same ssh session object to connect to a different remote host having same IP than previous host (just TCP port is different)