### PR TITLE
fix sudo test when using recent sudo versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     packages=['jumpssh'],

--- a/tests/docker/image_sshd/Dockerfile
+++ b/tests/docker/image_sshd/Dockerfile
@@ -21,7 +21,10 @@ RUN \
   chown -R user2:user2 /home/user2
 
 # give sudo permission to user1
-RUN echo "user1	 ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/my_sudoers
+RUN echo "user1	 ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/my_sudoers && \
+  # workaround for issue when using sudo => sudo: setrlimit(RLIMIT_CORE): Operation not permitted
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1773148
+  echo "Set disable_coredump false" > /etc/sudo.conf
 
 RUN ssh-keygen -A
 


### PR DESCRIPTION
this is a workaround to avoid error => sudo: setrlimit(RLIMIT_CORE): Operation not permitted
tracked by https://bugzilla.redhat.com/show_bug.cgi?id=1773148