### PR TITLE
remove pytest-runner from setup_requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,4 @@
-# required for sonar (https://docs.travis-ci.com/user/sonarqube/) and py37
-dist: xenial
-
-# required for docker and sonar
-sudo: required
-
 language: python
-
 cache: pip
 
 services:
@@ -34,11 +27,11 @@ python:
   - pypy
   - pypy3
 
-matrix:
+jobs:
   include:
-    - python: 3.7
+    - python: 3.8
       env: TOX_ENV=flake8
-    - python: 3.7
+    - python: 3.8
       env: TOX_ENV=docs
 
 install:
@@ -59,12 +52,12 @@ after_success:
 deploy:
   # deploys to PyPI on any tagged commit
   - provider: pypi
-    user: tcastaing
+    username: "__token__"
     password:
-      secure: "pZ523F3xk/yR29d429sleC72r4K0jo7KydOttvy/4708J8kMPFqmk7nrGmlcSUY3/RQ4mLP5ylTF507Hf4WxU7H/DbfJEc4bgctgwtXaEMwyGxc2x1lQpBf8ShqfFbCVFhwlR/ZBD3jeBXOzRFJ5v5eIhruiaE7QomYwjDtKVIAI1xPj2taM43r+ggQbVO8QBGp2ZdrQWZiN15a/hdjAUT4vVcsSvEEyQZE3yUslP2B7tFOTrAwBFRTfu2mkhy5eU7qkGcpYu9DHSE5dLf+XlbX3fz8ZUQBFDq16io3KrZavyUBnSeWCpkyqy867k+cAHbKXouNpGcuZRU2iyZVi5yKBN1iTFTiN8OmL+mFN9S2lepY2AyZ+9x4sv4SxAMJxlz36a5R7KsZgzPBHWvFdnxnertSNWOQm2fnom6B+msGWRxLnXpOQ+iHTa5JzCnB6Zy9vrvKliPzcmgu2Wpzs4n+8DbUAzDp09IZd0OOW/ZSGlhnp/YTA2W5zlmX60oGjljEe6MnxjJ+5p1GXY9D0yyl1nX1J8Ddv9IPia9EKa8Olfw5YNyLdOYzxqT7luGbLcU5ivWp3E7UwtGS4RnUNPcBBvR/7Lhpm2lI+ObFLRH0g+CEV3NXLc/TB3RKk7Z+t56o5jz0huqo7InZUkGnkF3zkLqxJQj/dPatxKKlkRV0="
+      secure: "i0WSXHnHn9S+N3+GYqQqJyTJdA9T7eKkVLJmacHMyVnseinD/1JHSjWcxUx9otFSn9nNo/Nhs67PGTyPLWPOlP4JfC7nmRUC9EvIHputRurkvzD7H3Gv0AzMej18LZof/dMoxioX5vMwjfUmjvUKJ3wMZeAJwtUIB9NJlwWC/O2SrjfhRD/Wv0JnmP49h9GUsbkbtGTki7810fOZBNeo1XPy6oSVnTErPKafuMIJs4EsQ8e4xiDWmlXRAs9zIOFdJ83l/RsEHw3o/8SFhvGfI/Zc4o78sU7Gw367mT/qrS5u1Qg8BMHjHaalGcD09fH/aCfPJ/Yww/gjAFrfcQgZeLp7AUwXMF1uGcIs/YKxihKRsr4QugMzjVEDJG2+RMdNM3YQ4DUd0D9dIFqYm7xEV4Emc+5kCrElPZwShL5QPr0fxJhhjnDCw+T7daQpP98vZ27gLXrE8hW/BwfDemmr3+ZYM55+hSoqK3hzv85V/BgN1f26u4NonzHXmINB3sQNGPT2apuPaZkBS3sBxYCf5TBZPiShEkX/cooyZZd1r7RwpubD/j45lLMLy+r/L9P+PKj+6dLh7SLZxFVExarnZiEcDC2Sgjdnv/v7XDGoLQLCNQsJJFC8X9rxMSOQVZu1j94yMTkuA6Zg7FTuHK5CDiIwoybMrztEUPwZJ2lv3j0="
+    distributions: sdist bdist_wheel
     on:
       tags: true
-      distributions: sdist bdist_wheel
       repo: AmadeusITGroup/JumpSSH
     # Upload artifacts only once
     skip_existing: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+1.6.2 (03/12/2020)
+------------------
+- [Improvement]: remove pytest-runner from setup_requires as this is deprecated for security reasons, see https://github.com/pytest-dev/pytest-runner
+- [Improvement]: use only fixed test dependencies in requirements_dev.txt
+
 1.6.1 (04/08/2019)
 ------------------
 - [Bug] :issue:`51`: 'get' file was failing if the remote file is binary. Thanks to :user:`pshaobow` for the report.

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ To run the test suite, clone the repository and run:
 
 .. code:: bash
 
-    $ python setup.py test
+    $ pytest -sv tests/
 
 or simply:
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,7 @@
 paramiko==2.7.1
-pytest>=3.0.4
-pytest-cov>=2.4.0
-mock>=2.0.0
+pytest==5.3.5;python_version>="3.5"
+pytest==4.6.9;python_version<"3.5"
+pytest-cov==2.8.1
+mock==3.0.5;python_version<"3.6"
+docker==4.2.0
 docker-compose==1.25.4

--- a/setup.py
+++ b/setup.py
@@ -57,15 +57,4 @@ setup(
     install_requires=[
         'paramiko'
     ],
-    test_suite='tests',
-    setup_requires=[
-        'pytest-runner'
-    ],
-    tests_require=[
-        'docker',
-        'docker-compose',
-        'pytest',
-        'pytest-catchlog',
-        'mock'
-    ]
 )


### PR DESCRIPTION
- remove pytest-runner from setup_requires as this is deprecated for security reasons, see https://github.com/pytest-dev/pytest-runner
- use fixed dependencies in requirements_dev.txt
- cleanup in travis.yml file