### PR TITLE
Fix run_cmd raising AuthenticationException if no agent is running

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ Next release
 ---------------
 - [Bug] :issue:`109`: Fix automated session closure handled by python garbage collection
 - [Bug] :issue:`120`: Fix get_remote_session not respecting 'timeout' parameter
+- [Bug] :issue:`139`: Fix run_cmd raising AuthenticationException if no agent is running
+
 
 1.6.3 (03/12/2020)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Next release
 - [Bug] :issue:`109`: Fix automated session closure handled by python garbage collection
 - [Bug] :issue:`120`: Fix get_remote_session not respecting 'timeout' parameter
 - [Bug] :issue:`139`: Fix run_cmd raising AuthenticationException if no agent is running
+- [Improvement][Tests]: use flaky package to automatically rerun flaky tests
 
 
 1.6.3 (03/12/2020)

--- a/jumpssh/session.py
+++ b/jumpssh/session.py
@@ -308,8 +308,10 @@ class SSHSession(object):
             # raise error rather than blocking the call
             channel.setblocking(0)
 
-            # Forward local agent
-            paramiko.agent.AgentRequestHandler(channel)
+            # Forward local agent if it is running and has some keys
+            # (If no agent is running, `get_keys` will return an empty tuple)
+            if paramiko.agent.Agent().get_keys():
+                paramiko.agent.AgentRequestHandler(channel)
             # Commands executed after this point will see the forwarded agent on the remote end.
 
             channel.set_combine_stderr(True)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@ paramiko==2.7.1
 pytest==5.4.0;python_version>="3.5"
 pytest==4.6.9;python_version<"3.5"
 pytest-cov==2.10.1
+flaky==3.7.0
 mock==3.0.5;python_version<"3.6"
 docker==4.3.0
 docker-compose==1.26.2

--- a/tests/test_restclient.py
+++ b/tests/test_restclient.py
@@ -8,6 +8,7 @@ import os
 import sys
 import tempfile
 
+from flaky import flaky
 import pytest
 
 from jumpssh import exception, SSHSession, RestSshClient
@@ -27,6 +28,7 @@ def docker_env():
     docker_compose_env.clean()
 
 
+@flaky
 def test_init_from_session(docker_env):
     gateway_ip, gateway_port = docker_env.get_host_ip_port('gateway')
     gateway_session = SSHSession(host=gateway_ip, port=gateway_port, username='user1', password='password1')


### PR DESCRIPTION
fix for #139 => only request forward of local agent if one is running and has some keys